### PR TITLE
Refactor/dom and event handling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,47 @@ const routes = {
   'dashboard': Dashboard,
 };
 
+//parent event listeners
+async function eventListener() {
+  
+  document.getElementById('app').addEventListener('click', async (e) => {
+    if (e.target.closest('[data-delete]')) {
+      // handle delete
+      if (window.confirm('Are you sure you want to delete this application?')) {
+        await deleteApplication(e.target.closest('[data-delete]').dataset.delete);
+        await render();
+      }; 
+    }
+    if (e.target.closest('[data-id]')) {
+      // handle status
+      const span = e.target.closest('[data-id]');
+      const select = document.createElement('select');
+      select.style.width = 'auto';
+
+      ['applied', 'interview', 'offer', 'rejected'].forEach(option => {
+        const opt = document.createElement('option');
+        opt.value = option;
+        opt.textContent = option;
+        if (option === span.dataset.status) opt.selected = true;
+        select.appendChild(opt);
+      });
+
+      select.dataset.id = span.dataset.id;
+      span.replaceWith(select);
+
+      select.addEventListener('change', async () => {
+        await updateApplication(select.dataset.id, { status: select.value });
+        await render();
+      });
+    }
+  });
+
+
+
+
+ 
+}
+
 //page renderer for dynamic loading
 async function render() {
   const hash = window.location.hash.slice(1) || '';
@@ -39,41 +80,9 @@ async function render() {
     setupApplicationFilters(render);
   }
 
-  // TODO: replace per-element listeners below with a single delegated listener on #app
-  // to avoid re-attaching on every render
-  document.querySelectorAll('[data-delete]').forEach(Xbutton => {
-    Xbutton.addEventListener('click', async () => {
-      if (window.confirm('Are you sure you want to delete this application?')) {
-        await deleteApplication(Xbutton.dataset.id);
-        await render();
-      }
-    }); 
-  });
-
-  document.querySelectorAll('[data-id]').forEach(Status_span => {
-    Status_span.addEventListener('click', async () => {
-      const span = Status_span;
-      const select = document.createElement('select');
-      select.style.width = 'auto';
-
-      ['applied', 'interview', 'offer', 'rejected'].forEach(option => {
-        const opt = document.createElement('option');
-        opt.value = option;
-        opt.textContent = option;
-        if (option === span.dataset.status) opt.selected = true;
-        select.appendChild(opt);
-      });
-
-      select.dataset.id = span.dataset.id;
-      span.replaceWith(select);
-
-      select.addEventListener('change', async () => {
-        await updateApplication(select.dataset.id, { status: select.value });
-        await render();
-      });
-    });
-  });
+ 
 }
 
 window.addEventListener('hashchange', render);
 render();
+eventListener();

--- a/src/main.js
+++ b/src/main.js
@@ -20,11 +20,15 @@ const routes = {
 async function render() {
   const hash = window.location.hash.slice(1) || '';
   const page = routes[hash];
+  const result = page ? await page() : '<p>Page not found</p>';
+  const html = typeof result === 'object' ? result.html : result;
   document.getElementById('app').innerHTML = `
-    ${Header()}
-    ${page ? await page() : '<p>Page not found</p>'}
-    ${Footer()}
+  ${Header()}
+  ${html}
+  ${Footer()}
   `;
+  if (result.init) result.init();
+
   if (hash === 'dashboard') {
     await initDashboard();
   }

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,6 @@ import { Applications, setupApplicationFilters } from './pages/Applications/Appl
 import { deleteApplication, updateApplication } from './utils/storage.js';
 import { Dashboard } from './pages/Dashboard/Dashboard.js';
 import { initDashboard } from './pages/Dashboard/DashboardInit.js';
-import { supabase } from './utils/supabase.js';
 
 //url navigation
 const routes = {
@@ -36,10 +35,12 @@ async function render() {
     setupApplicationFilters(render);
   }
 
+  // TODO: replace per-element listeners below with a single delegated listener on #app
+  // to avoid re-attaching on every render
   document.querySelectorAll('[data-delete]').forEach(Xbutton => {
     Xbutton.addEventListener('click', async () => {
       if (window.confirm('Are you sure you want to delete this application?')) {
-        await deleteApplication(Xbutton.dataset.delete);
+        await deleteApplication(Xbutton.dataset.id);
         await render();
       }
     }); 
@@ -70,36 +71,5 @@ async function render() {
   });
 }
 
-window.addEventListener('hashchange', render); // re-renders page content and re-attaches event listeners on every navigation
+window.addEventListener('hashchange', render);
 render();
-
-// online/offline indicator
-function createConnectionIndicator() {
-  const indicator = document.createElement('div');
-  indicator.id = 'connection-indicator';
-  indicator.className = 'connection-indicator';
-  document.body.appendChild(indicator);
-  return indicator;
-}
-
-async function updateConnectionIndicator() {
-  let indicator = document.getElementById('connection-indicator');
-  if (!indicator) indicator = createConnectionIndicator();
-
-  if (!supabase) { // debugging branch for renaming the .env file
-    indicator.innerHTML = '<span class="connection-dot connection-dot--offline"></span>offline';
-    return;
-  }
-
-  try { // probe supabase for response, or default to offline
-    const { error } = await supabase.from('applications').select('id').limit(1);
-    if (error) throw error;
-    indicator.innerHTML = '<span class="connection-dot connection-dot--online"></span>online';
-  } catch {
-    indicator.innerHTML = '<span class="connection-dot connection-dot--offline"></span>offline';
-  }
-}
-
-createConnectionIndicator();
-updateConnectionIndicator();
-setInterval(updateConnectionIndicator, 30000);

--- a/src/pages/AddApplication/AddApplication.js
+++ b/src/pages/AddApplication/AddApplication.js
@@ -3,9 +3,9 @@ import { saveApplication } from '../../utils/storage.js';
 
 
 export function AddApplication() {
-  // TODO: replace setTimeout with document.createElement so JS and HTML are created
-  // together and listeners can attach without a timing hack
-  setTimeout(() => {
+
+  return {html: template, init: () => {
+    
     const form = document.getElementById('applicationForm');
 
     // Restore draft if one exists
@@ -14,10 +14,15 @@ export function AddApplication() {
       const data = JSON.parse(draft);
       document.getElementById('company').value = data.company || '';
       document.getElementById('role').value = data.role || '';
-      document.getElementById('date').value = data.date || '';
+      document.getElementById('date').value = data.date || new Date().toISOString().split('T')[0];
       document.getElementById('location').value = data.location || '';
       document.getElementById('status').value = data.status || '';
-    }
+      document.getElementById('notes').value = data.notes || '';
+    } 
+
+    document.getElementById('date').value = document.getElementById('date').value || new Date().toISOString().split('T')[0]; // defaults to today to avoid failing field validation
+
+
 
     // Save draft on every input change
     form.addEventListener('input', () => {
@@ -27,6 +32,7 @@ export function AddApplication() {
         date: document.getElementById('date').value,
         location: document.getElementById('location').value,
         status: document.getElementById('status').value,
+        notes: document.getElementById('notes').value,
       }));
     });
 
@@ -38,6 +44,7 @@ export function AddApplication() {
       const date = document.getElementById('date');
       const location = document.getElementById('location');
       const status = document.getElementById('status');
+      const notes = document.getElementById('notes');
 
       let isValid = true;
 
@@ -97,6 +104,7 @@ export function AddApplication() {
           date: date.value,
           location: location.value,
           status: status.value,
+          notes: notes.value,
         });
         localStorage.removeItem('form_draft');
         alert(" Application added successfully!");
@@ -110,8 +118,6 @@ export function AddApplication() {
     }
 
     )
-  }, 0);
-
-
-  return template;
+  
+  }};
 }

--- a/src/pages/AddApplication/AddApplication.js
+++ b/src/pages/AddApplication/AddApplication.js
@@ -3,7 +3,9 @@ import { saveApplication } from '../../utils/storage.js';
 
 
 export function AddApplication() {
-  setTimeout(() => { // defers the execution until the stack finishes and the DOM is updated
+  // TODO: replace setTimeout with document.createElement so JS and HTML are created
+  // together and listeners can attach without a timing hack
+  setTimeout(() => {
     const form = document.getElementById('applicationForm');
 
     // Restore draft if one exists


### PR DESCRIPTION
## Summary
- Replaced `setTimeout` timing hack in `AddApplication` with a two-part return (`html` + `init`), so listeners attach after the DOM is ready
- Replaced per-element `querySelectorAll` listeners in `render()` with a single delegated listener on `#app`, eliminating redundant re-attachment on every render
- Updated `render()` to handle both string and object return values from page functions
- Added `notes` to the form so its actually submitted to the database and persists when reloading 

