### PR TITLE
Fix/final polish

### DIFF
--- a/src/components/applications/renderTable.js
+++ b/src/components/applications/renderTable.js
@@ -25,7 +25,7 @@ const tableStyles = {
 
 export function renderApplications(applications) {
   return `
-    <div class="w-full md:w-3/4 mx-auto mt-6">
+    <div class="w-full lg:w-3/4 lg:mx-auto mt-6">
       <!-- Scroll container for the entire table block -->
       <div class="overflow-x-auto pb-4">
         
@@ -67,7 +67,7 @@ export function renderApplications(applications) {
                 </td>
                 
                 <td class="py-4 px-6 ${tableStyles.cellRight}">
-                  <div class="flex justify-end gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div class="flex justify-end gap-2 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity">
                     <!-- Edit button -->
                     <button data-edit="${app.id}" class="hover:text-orange-500">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">

--- a/src/components/applications/renderViewToggle.js
+++ b/src/components/applications/renderViewToggle.js
@@ -4,7 +4,7 @@ export function renderViewToggle(viewMode) {
   const isTableChecked = viewMode === "table" ? "checked" : "";  
 
   return `
-    <div class="flex justify-center mb-5">
+    <div class="hidden sm:flex justify-center mb-5">
       <label class="inline-flex items-center cursor-pointer">
         <span class="select-none text-sm font-medium text-heading">
           Cards

--- a/src/components/layout/Header/Header.html
+++ b/src/components/layout/Header/Header.html
@@ -1,10 +1,10 @@
 <header class="header fixed top-0 w-full z-20">
-    <nav class="flex items-center justify-between px-8 h-14">
-        <a href="#" class="font-bold text-xl tracking-tight" style="font-family: 'Syne', sans-serif;">Jobify</a>
+    <nav class="flex items-center justify-between px-4 sm:px-8 h-14">
+        <a href="#" class="font-bold text-xl tracking-tight pr-8 sm:pr-0" style="font-family: 'Syne', sans-serif;">J<span class="hidden sm:inline">obify</span></a>
         <div class="flex items-center gap-1">
-            <a href="#applications" class="nav-link text-sm px-4 py-1.5 rounded-lg transition-all">Applications</a>
-            <a href="#dashboard" class="nav-link text-sm px-4 py-1.5 rounded-lg transition-all">Dashboard</a>
-            <a href="#add-application" class="btn ml-2 text-sm">+ Add Application</a>
+            <a href="#applications" class="nav-link text-sm px-2 sm:px-4 py-1.5 rounded-lg transition-all">Applications</a>
+            <a href="#dashboard" class="nav-link text-sm px-2 sm:px-4 py-1.5 rounded-lg transition-all">Dashboard</a>
+            <a href="#add-application" class="btn ml-2 text-sm !px-3 sm:!px-6">+ Add App<span class="hidden sm:inline">lication</span></a>
         </div>
     </nav>
 </header>

--- a/src/components/layout/Header/Header.html
+++ b/src/components/layout/Header/Header.html
@@ -2,7 +2,6 @@
     <nav class="flex items-center justify-between px-8 h-14">
         <a href="#" class="font-bold text-xl tracking-tight" style="font-family: 'Syne', sans-serif;">Jobify</a>
         <div class="flex items-center gap-1">
-            <a href="#" class="nav-link text-sm px-4 py-1.5 rounded-lg transition-all">Home</a>
             <a href="#applications" class="nav-link text-sm px-4 py-1.5 rounded-lg transition-all">Applications</a>
             <a href="#dashboard" class="nav-link text-sm px-4 py-1.5 rounded-lg transition-all">Dashboard</a>
             <a href="#add-application" class="btn ml-2 text-sm">+ Add Application</a>

--- a/src/pages/Applications/Applications.js
+++ b/src/pages/Applications/Applications.js
@@ -37,8 +37,8 @@ export async function Applications() {
       ${renderViewToggle(viewMode)}
 
       <div id="applications-list">
-        ${viewMode === "cards" 
-          ? renderCards(filteredApplications) 
+        ${(viewMode === "cards" || window.innerWidth < 640)
+          ? renderCards(filteredApplications)
           : renderApplications(filteredApplications)
         }
       </div>

--- a/src/pages/Dashboard/Dashboard.html
+++ b/src/pages/Dashboard/Dashboard.html
@@ -12,7 +12,7 @@
                     <!--top total ?chart-->
                     <div class="flex flex-col md:flex-row gap-6">
                          <!--total applications chart-->
-                         <div class="flex-1  card p-6 md:p-8 text-center">
+                         <div class="flex-1 card p-6 md:p-8 text-center flex flex-col justify-center">
                               <h2 class="text-lg md:text-xl font-semibold mb-2 ">TOTAL APPLICATIONS</h2>
                               <p id="totalapps" class="text-3xl md:text-5xl font-bold"></p>
                          </div>
@@ -57,11 +57,34 @@
                          <!--stats-->
                          <div id="stats" class="grid grid-cols-1 md:grid-cols-2 gap-4">
 
-                              <div class="card p-4 text-center">
+                              <div class="card p-4 text-center flex flex-col justify-center">
                                    <h2 class="text-sm md:text-base ">Average Time to Response</h2>
                                    <p id="averageResponseRate" class="text-xl md:text-2xl font-bold"></p>
 
                               </div>
+
+                              <!--conversion rate-->
+                         <div class="card p-6 md:p-8 text-center">
+
+                          <h2 class="text-lg font-semibold mb-4">
+                                   Conversion Rate
+                              </h2>
+                              <div class="grid grid-cols-1 gap-4">
+                                   <div>
+                                        <h3 class="text-sm">Applied to Interview Rate</h3>
+                                        <span id="appliedToInterviewRate" class="text-2xl font-bold"></span>
+                                   </div>
+                                   <div>
+                                        <h3 class="text-sm">Interview to Offer Rate</h3>
+                                        <span id="interviewToOfferRate" class="text-2xl font-bold"></span>
+                                   </div>
+                                   
+
+
+
+                              </div>
+
+                         </div>
 
                               
 
@@ -133,28 +156,7 @@
                               </div>
 
                          </div>
-                         <!--conversion rate-->
-                         <div class="card p-6 md:p-8 text-center">
-
-                          <h2 class="text-lg font-semibold mb-4">
-                                   Conversion Rate
-                              </h2>
-                              <div class="grid grid-cols-1 gap-4">
-                                   <div>
-                                        <h3 class="text-sm">Applied to Interview Rate</h3>
-                                        <span id="appliedToInterviewRate" class="text-2xl font-bold"></span>
-                                   </div>
-                                   <div>
-                                        <h3 class="text-sm">Interview to Offer Rate</h3>
-                                        <span id="interviewToOfferRate" class="text-2xl font-bold"></span>
-                                   </div>
-                                   
-
-
-
-                              </div>
-
-                         </div>
+                         
                     </div>
 
                

--- a/src/pages/Dashboard/Dashboard.html
+++ b/src/pages/Dashboard/Dashboard.html
@@ -91,7 +91,7 @@
                          </div>
                </div>
                     <!-- right side -->
-                    <div class="flex flex-col gap-6">
+                    <div class="flex flex-col gap-6 h-full">
                          <!--recent applications-->
                          <div class="card p-6 md:p-8">
                               <h2 class="text-lg font-semibold mb-4 text-center">Recent Entry</h2>
@@ -132,7 +132,7 @@
 
                          </div>
                          <!--response rate-->
-                         <div class="card p-6 md:p-8 text-center">
+                         <div class="card p-6 md:p-8 text-center flex-1 flex flex-col justify-center">
 
                           <h2 class="text-lg font-semibold mb-4">
                                    Statuses

--- a/src/pages/Dashboard/DashboardInit.js
+++ b/src/pages/Dashboard/DashboardInit.js
@@ -73,9 +73,17 @@ function renderRates(stats) {
 
 
 function renderConversionRates(stats, status_history) {
-  // make sets of applications in only interview or offer status
+  // make sets of applications in only interview THEN offer status
   const interviewedIds = new Set(status_history.filter(r => r.status === 'interview').map(r => r.application_id));
-  const offeredIds = new Set(status_history.filter(r => r.status === 'offer').map(r => r.application_id));
+  const offeredIds = new Set(
+    // filter out only apps that were in interview THEN offer 
+    [...interviewedIds].filter(id => {
+      const firstInterview = Math.min(...status_history.filter(r => r.application_id === id && r.status === 'interview').map(r => new Date (r.changed_at)));
+      const firstOffer = Math.min(...status_history.filter(r => r.application_id === id && r.status === 'offer').map(r => new Date (r.changed_at)));
+      return isFinite(firstOffer) && firstOffer > firstInterview;
+    })
+  );
+
 
   // percentage of applications that went from applied to interview status
   const appliedToInterviewRate = stats.total === 0 ? 0 :
@@ -105,7 +113,7 @@ function renderAverageResponseRate(stats, applications, status_history) {
   }
 
 
-  const averageResponseRate = (responseTimes.reduce((a,b) => a + b, 0) / responseTimes.length);
+  const averageResponseRate = (responseTimes.reduce((a,b) => a + b, 0) / responseTimes.length).toFixed(1);
   document.getElementById('averageResponseRate').textContent = `${averageResponseRate} days`;
 
 }

--- a/src/style.css
+++ b/src/style.css
@@ -79,6 +79,7 @@ body {
   text-decoration: none;
 }
 
+
 .nav-link:hover {
   color: #16a34a;
   background: var(--nav-hover-bg);


### PR DESCRIPTION
Final polish pass before sprint 6 wrap-up.

**Changes:**
- Responsive navbar: logo collapses to "J" on mobile, nav links tighten, button text shortens to "+ Add App"
- Table view hidden on mobile, cards forced on small screens
- View toggle hidden on mobile (cards only below `sm` breakpoint)
- Table action buttons always visible on mobile, hover-only on desktop
- Conversion rate logic corrected to only count offers that followed an interview in sequence
- Average response time rounded to 1 decimal place
- Dashboard conversion rate card moved to left column for better layout balance
- Minor dashboard flex alignment improvements